### PR TITLE
ci: Move to upload-private-artifacts-action

### DIFF
--- a/.github/workflows/build-check-sdk.yaml
+++ b/.github/workflows/build-check-sdk.yaml
@@ -129,34 +129,17 @@ jobs:
             -DCMAKE_PREFIX_PATH="$(pwd)/install/share" \
             -DBUILD_TESTING=OFF
 
-      - name: Publish artifacts
+      - name: Stage build artifacts for publishing
         continue-on-error: true
         run: |
-          build_dir=${PERSIST_DIR}/builds/${GITHUB_RUN_ID}
+          build_dir=./uploads
           mkdir -p $build_dir
 
           tar -cvf ${build_dir}/${{ github.event.repository.name }}-${MACHINE}-${DISTRO}-${QCOM_SELECTED_BSP}-artifacts.tar --transform "s|^${WORKSPACE}/||" -C ${WORKSPACE} install build log
 
-          # Instruct our file server to make these files available for download
-          url="https://quic-qrt-ros-fileserver-1029608027416.us-central1.run.app/${GITHUB_RUN_ID}/"
-          retries=8
-          okay=0
-          shopt -s lastpipe  # allows us to capture the value of `okay` in the while loop below
-          for ((i=0; i<retries; i++)); do
-              curl -X POST -H "Accept: text/event-stream" -i --fail-with-body -s -N ${url} | \
-                  while read -r line; do
-                      echo $line
-                      if [[ $line == STATUS=* ]]; then
-                          if [[ $line == "STATUS=OK" ]]; then
-                              okay=1
-                              break
-                          fi
-                      fi
-                  done
-              [ $okay -eq 1 ] && break
-              echo # new line break in case response doesn't have one
-              echo "Error: unable to publish artifacts, sleep and retry"
-              sleep 2
-          done
-          (( retries == i )) && { echo 'Failed to publish artifacts'; exit 1; }
-          echo Artifacts available at: ${url}
+      - name: Upload private artifacts
+        continue-on-error: true
+        uses: qualcomm-linux/upload-private-artifact-action@v1
+        with:
+          path: ./uploads
+          fileserver_url: "https://quic-qrt-ros-fileserver-1029608027416.us-central1.run.app"


### PR DESCRIPTION
This action will allow us to keep the logic for publishing artifacts in one place that can be maintained separate from all the projects that use it. This action brings in a number of improvements including:

 * Publishing no longer requires being run from a GCP self-hosted runner
 * Better retry logic